### PR TITLE
Removed the routeDelete function; replaced callback with .deleteMsg

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -15,11 +15,11 @@
 		 buttonSubmit.addEventListener("click", msgSubmit);			// Listens for click; runs function to begin the process of creating a new message
 
 		 var buttonClearAll = document.getElementById("clear");				// Grabs clear button
-		 buttonClearAll.addEventListener("click", Chatty.deleteAll);		// Listens for click; calls Chatty.deleteAll()
+		 buttonClearAll.addEventListener("click", Chatty.deleteAll);	// Listens for click; calls Chatty.deleteAll()
 
 	// Main content elements
 		 var msgArea = document.getElementById("msgArea");			// Grabs the output div where all messages appear
-		 msgArea.addEventListener("click", routeDelete);					// Listens for click; runs function that calls Chatty.deleteMsg and passes in event.target
+		 msgArea.addEventListener("click", Chatty.deleteMsg);		// Listens for click; runs function that calls Chatty.deleteMsg and passes in event.target
 
 		 var contentWrap = document.getElementById("wrapper");	// Grabs the content wrapper for toggling light/dark themes and regular/large text
 
@@ -55,10 +55,3 @@
   		function msgSubmit() {
   			Chatty.addNewMessage(userInput.value);
   		}
-
-	// msgDelete() - Callback from msgArea
-		// When a delete button is clicked,
-		// the parent message of the delete button is passed into Chatty.deleteMsg()
-			function routeDelete(clickEvent) {
-				Chatty.deleteMsg(clickEvent.target);
-			}


### PR DESCRIPTION
The routeDelete callback function was redundant, so I deleted it and replaced it with Chatty.deleteMsg. The event info is now passed directly to that method.
